### PR TITLE
fix: Attempt to have full coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,6 @@ jobs:
       - name: Build
         run: go build -v ./...
       - name: Run tests with the Go CLI
-        run: go test ./... -race -covermode=atomic -coverprofile=coverage.out
+        run: go test ./... -coverpkg=./... -race -covermode=atomic -coverprofile=coverage.out
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
# Work

* Detected that some packages where there are no test files are ignored from the coverage.
* Using this [link](https://stackoverflow.com/questions/58513640/how-to-include-all-files-in-go-code-coverage-calculations) it seems like we can have them in the report.