### PR TITLE
feat: Result interface and new executor method

### DIFF
--- a/cmd/create-user/main.go
+++ b/cmd/create-user/main.go
@@ -35,8 +35,9 @@ func main() {
 
 func createUserCmdBody(cmd *cobra.Command, args []string) {
 	userDto := dtos.UserDto{
-		Id:       uuid.New(),
-		Mail:     "toto@some-mail.com",
+		Id: uuid.New(),
+		// Id:       uuid.MustParse("cce2e9f5-bc02-402c-9f65-246869c57540"),
+		Mail:     "toto@some-mail3.com",
 		Name:     "toto",
 		Password: "123456",
 	}

--- a/pkg/db/command_tag.go
+++ b/pkg/db/command_tag.go
@@ -1,0 +1,23 @@
+package db
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/KnoblauchPilze/go-game/pkg/errors"
+	"github.com/jackc/pgx"
+)
+
+func extractAffectedRowsFromCommandTag(tag pgx.CommandTag) (int, error) {
+	pieces := strings.Split(string(tag), " ")
+	if len(pieces) != 3 {
+		return 0, errors.NewCode(errors.ErrInvalidSqlCommandTag)
+	}
+
+	affected, err := strconv.Atoi(pieces[2])
+	if err != nil {
+		return 0, errors.WrapCode(err, errors.ErrInvalidSqlCommandTag)
+	}
+
+	return affected, nil
+}

--- a/pkg/db/command_tag.go
+++ b/pkg/db/command_tag.go
@@ -8,13 +8,33 @@ import (
 	"github.com/jackc/pgx"
 )
 
+var deleteCommandTag = "DELETE"
+var insertCommandTag = "INSERT"
+
 func extractAffectedRowsFromCommandTag(tag pgx.CommandTag) (int, error) {
 	pieces := strings.Split(string(tag), " ")
-	if len(pieces) != 3 {
+	if len(pieces) != 2 && len(pieces) != 3 {
 		return 0, errors.NewCode(errors.ErrInvalidSqlCommandTag)
 	}
 
-	affected, err := strconv.Atoi(pieces[2])
+	switch pieces[0] {
+	case deleteCommandTag:
+		if len(pieces) != 2 {
+			return 0, errors.NewCode(errors.ErrInvalidSqlCommandTag)
+		}
+		return extractRows(pieces[1])
+	case insertCommandTag:
+		if len(pieces) != 3 {
+			return 0, errors.NewCode(errors.ErrInvalidSqlCommandTag)
+		}
+		return extractRows(pieces[2])
+	default:
+		return 0, errors.NewCode(errors.ErrUnknownSqlCommandTag)
+	}
+}
+
+func extractRows(rows string) (int, error) {
+	affected, err := strconv.Atoi(rows)
 	if err != nil {
 		return 0, errors.WrapCode(err, errors.ErrInvalidSqlCommandTag)
 	}

--- a/pkg/db/command_tag_test.go
+++ b/pkg/db/command_tag_test.go
@@ -1,0 +1,32 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/KnoblauchPilze/go-game/pkg/errors"
+	"github.com/jackc/pgx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractAffectedRowsFromCommandTag_Invalid(t *testing.T) {
+	assert := assert.New(t)
+
+	tag := pgx.CommandTag("invalidTag")
+	_, err := extractAffectedRowsFromCommandTag(tag)
+	assert.True(errors.IsErrorWithCode(err, errors.ErrInvalidSqlCommandTag))
+
+	tag = pgx.CommandTag("insert 0 not-a-number")
+	_, err = extractAffectedRowsFromCommandTag(tag)
+	assert.True(errors.IsErrorWithCode(err, errors.ErrInvalidSqlCommandTag))
+	cause := errors.Unwrap(err)
+	assert.Contains(cause.Error(), "parsing \"not-a-number\": invalid syntax")
+}
+
+func TestExtractAffectedRowsFromCommandTag(t *testing.T) {
+	assert := assert.New(t)
+
+	tag := pgx.CommandTag("insert 12 24")
+	n, err := extractAffectedRowsFromCommandTag(tag)
+	assert.Nil(err)
+	assert.Equal(24, n)
+}

--- a/pkg/db/command_tag_test.go
+++ b/pkg/db/command_tag_test.go
@@ -8,6 +8,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestExtractRows(t *testing.T) {
+	assert := assert.New(t)
+
+	_, err := extractRows("not-a-number")
+	assert.True(errors.IsErrorWithCode(err, errors.ErrInvalidSqlCommandTag))
+
+	n, err := extractRows("32")
+	assert.Equal(32, n)
+	assert.Nil(err)
+}
+
 func TestExtractAffectedRowsFromCommandTag_Invalid(t *testing.T) {
 	assert := assert.New(t)
 
@@ -15,17 +26,48 @@ func TestExtractAffectedRowsFromCommandTag_Invalid(t *testing.T) {
 	_, err := extractAffectedRowsFromCommandTag(tag)
 	assert.True(errors.IsErrorWithCode(err, errors.ErrInvalidSqlCommandTag))
 
-	tag = pgx.CommandTag("insert 0 not-a-number")
+	tag = pgx.CommandTag("invalidTag with many fields")
 	_, err = extractAffectedRowsFromCommandTag(tag)
 	assert.True(errors.IsErrorWithCode(err, errors.ErrInvalidSqlCommandTag))
-	cause := errors.Unwrap(err)
-	assert.Contains(cause.Error(), "parsing \"not-a-number\": invalid syntax")
 }
 
-func TestExtractAffectedRowsFromCommandTag(t *testing.T) {
+func TestExtractAffectedRowsFromCommandTag_UnknownTag(t *testing.T) {
 	assert := assert.New(t)
 
-	tag := pgx.CommandTag("insert 12 24")
+	tag := pgx.CommandTag("UNKNOWN_VERB ok fields")
+	_, err := extractAffectedRowsFromCommandTag(tag)
+	assert.True(errors.IsErrorWithCode(err, errors.ErrUnknownSqlCommandTag))
+}
+
+func TestExtractAffectedRowsFromCommandTag_Insert(t *testing.T) {
+	assert := assert.New(t)
+
+	tag := pgx.CommandTag("INSERT 24")
+	_, err := extractAffectedRowsFromCommandTag(tag)
+	assert.True(errors.IsErrorWithCode(err, errors.ErrInvalidSqlCommandTag))
+
+	tag = pgx.CommandTag("INSERT 0 not-a-number")
+	_, err = extractAffectedRowsFromCommandTag(tag)
+	assert.True(errors.IsErrorWithCode(err, errors.ErrInvalidSqlCommandTag))
+
+	tag = pgx.CommandTag("INSERT 0 37")
+	n, err := extractAffectedRowsFromCommandTag(tag)
+	assert.Nil(err)
+	assert.Equal(37, n)
+}
+
+func TestExtractAffectedRowsFromCommandTag_Deleted(t *testing.T) {
+	assert := assert.New(t)
+
+	tag := pgx.CommandTag("DELETE not-a-number")
+	_, err := extractAffectedRowsFromCommandTag(tag)
+	assert.True(errors.IsErrorWithCode(err, errors.ErrInvalidSqlCommandTag))
+
+	tag = pgx.CommandTag("DELETE 23 additional-argument")
+	_, err = extractAffectedRowsFromCommandTag(tag)
+	assert.True(errors.IsErrorWithCode(err, errors.ErrInvalidSqlCommandTag))
+
+	tag = pgx.CommandTag("DELETE 24")
 	n, err := extractAffectedRowsFromCommandTag(tag)
 	assert.Nil(err)
 	assert.Equal(24, n)

--- a/pkg/db/postgres_db.go
+++ b/pkg/db/postgres_db.go
@@ -130,16 +130,12 @@ func (db *postgresDb) Execute(ctx context.Context, query Query) Result {
 	db.lock.Lock()
 	defer db.lock.Unlock()
 
-	var out Result
-
 	if db.pool == nil {
-		out.Err = errors.NewCode(errors.ErrDbConnectionInvalid)
-		return out
+		return newResult("", errors.NewCode(errors.ErrDbConnectionInvalid))
 	}
 
 	if !query.Valid() {
-		out.Err = errors.NewCode(errors.ErrInvalidQuery)
-		return out
+		return newResult("", errors.NewCode(errors.ErrInvalidQuery))
 	}
 
 	sqlQuery := query.ToSql()
@@ -159,13 +155,10 @@ func (db *postgresDb) Execute(ctx context.Context, query Query) Result {
 	err := common.ExecuteWithContext(p, ctx, db.config.DbQueryTimeout)
 	if err != nil {
 		if err == context.DeadlineExceeded {
-			out.Err = errors.WrapCode(err, errors.ErrDbRequestTimeout)
-			return out
+			return newResult("", errors.WrapCode(err, errors.ErrDbRequestTimeout))
 		}
-		out.Err = errors.WrapCode(err, errors.ErrDbRequestFailed)
-		return out
+		return newResult("", errors.WrapCode(err, errors.ErrDbRequestFailed))
 	}
 
-	out.tag = tag
-	return out
+	return newResult(tag, nil)
 }

--- a/pkg/db/postgres_db_test.go
+++ b/pkg/db/postgres_db_test.go
@@ -227,7 +227,7 @@ func TestPostgresDatabase_Execute_NotConnected(t *testing.T) {
 
 	q := queryImpl{}
 	rows := db.Execute(context.TODO(), q)
-	assert.True(errors.IsErrorWithCode(rows.Err, errors.ErrDbConnectionInvalid))
+	assert.True(errors.IsErrorWithCode(rows.Err(), errors.ErrDbConnectionInvalid))
 }
 
 func TestPostgresDatabase_Execute_Invalid(t *testing.T) {
@@ -245,7 +245,7 @@ func TestPostgresDatabase_Execute_Invalid(t *testing.T) {
 
 	q := queryImpl{}
 	rows := db.Execute(ctx, q)
-	assert.True(errors.IsErrorWithCode(rows.Err, errors.ErrInvalidQuery))
+	assert.True(errors.IsErrorWithCode(rows.Err(), errors.ErrInvalidQuery))
 }
 
 func TestPostgresDatabase_Execute(t *testing.T) {
@@ -312,8 +312,8 @@ func TestPostgresDatabase_Execute_Fail(t *testing.T) {
 		sqlCode: "someSqlCode",
 	}
 	result := db.Execute(ctx, q)
-	assert.True(errors.IsErrorWithCode(result.Err, errors.ErrDbRequestFailed))
-	cause := errors.Unwrap(result.Err)
+	assert.True(errors.IsErrorWithCode(result.Err(), errors.ErrDbRequestFailed))
+	cause := errors.Unwrap(result.Err())
 	assert.Equal(errDefault, cause)
 }
 
@@ -339,8 +339,8 @@ func TestPostgresDatabase_Execute_Timeout(t *testing.T) {
 	result := db.Execute(ctx, q)
 	// Wait for query to finish with some margin.
 	time.Sleep(2 * defaultSleep)
-	assert.True(errors.IsErrorWithCode(result.Err, errors.ErrDbRequestTimeout))
-	cause := errors.Unwrap(result.Err)
+	assert.True(errors.IsErrorWithCode(result.Err(), errors.ErrDbRequestTimeout))
+	cause := errors.Unwrap(result.Err())
 	assert.Equal(context.DeadlineExceeded, cause)
 }
 

--- a/pkg/db/postgres_db_test.go
+++ b/pkg/db/postgres_db_test.go
@@ -252,7 +252,9 @@ func TestPostgresDatabase_Execute(t *testing.T) {
 	assert := assert.New(t)
 
 	config := testConfig
-	mockDb := &mockPgxDbFacade{}
+	mockDb := &mockPgxDbFacade{
+		tag: "insert 0 12",
+	}
 	config.creationFunc = func(config pgx.ConnPoolConfig) (pgxDbFacade, error) {
 		return mockDb, nil
 	}
@@ -265,7 +267,8 @@ func TestPostgresDatabase_Execute(t *testing.T) {
 		sqlCode: "someSqlCode",
 	}
 	result := db.Execute(ctx, q)
-	assert.Nil(result.Err)
+	assert.Nil(result.Err())
+	assert.Equal(12, result.AffectedRows())
 	assert.Equal(1, len(mockDb.sqlExecuteReceived))
 	assert.Equal("someSqlCode", mockDb.sqlExecuteReceived[0])
 }
@@ -274,7 +277,9 @@ func TestPostgresDatabase_Execute_Verbose(t *testing.T) {
 	assert := assert.New(t)
 
 	config := testConfig
-	mockDb := &mockPgxDbFacade{}
+	mockDb := &mockPgxDbFacade{
+		tag: "insert 0 12",
+	}
 	config.creationFunc = func(config pgx.ConnPoolConfig) (pgxDbFacade, error) {
 		return mockDb, nil
 	}
@@ -288,7 +293,8 @@ func TestPostgresDatabase_Execute_Verbose(t *testing.T) {
 		verbose: true,
 	}
 	result := db.Execute(ctx, q)
-	assert.Nil(result.Err)
+	assert.Nil(result.Err())
+	assert.Equal(12, result.AffectedRows())
 	assert.Equal(1, len(mockDb.sqlExecuteReceived))
 	assert.Equal("someSqlCode", mockDb.sqlExecuteReceived[0])
 }

--- a/pkg/db/postgres_db_test.go
+++ b/pkg/db/postgres_db_test.go
@@ -253,7 +253,7 @@ func TestPostgresDatabase_Execute(t *testing.T) {
 
 	config := testConfig
 	mockDb := &mockPgxDbFacade{
-		tag: "insert 0 12",
+		tag: "INSERT 0 12",
 	}
 	config.creationFunc = func(config pgx.ConnPoolConfig) (pgxDbFacade, error) {
 		return mockDb, nil
@@ -278,7 +278,7 @@ func TestPostgresDatabase_Execute_Verbose(t *testing.T) {
 
 	config := testConfig
 	mockDb := &mockPgxDbFacade{
-		tag: "insert 0 12",
+		tag: "INSERT 0 12",
 	}
 	config.creationFunc = func(config pgx.ConnPoolConfig) (pgxDbFacade, error) {
 		return mockDb, nil

--- a/pkg/db/query_executor.go
+++ b/pkg/db/query_executor.go
@@ -58,8 +58,11 @@ func (qe *queryExecutorImpl) ExecuteQueryAffectingSingleRow(ctx context.Context,
 		return err
 	}
 
-	if res.AffectedRows() != 1 {
+	if res.AffectedRows() == 0 {
 		return errors.NewCode(errors.ErrSqlQueryDidNotAffectSingleRow)
+	}
+	if res.AffectedRows() > 1 {
+		return errors.NewCode(errors.ErrSqlQueryAffectedMultipleRows)
 	}
 
 	return nil

--- a/pkg/db/query_executor_test.go
+++ b/pkg/db/query_executor_test.go
@@ -273,7 +273,7 @@ func TestQueryExecutor_ExecuteQueryAffectingSingleRow_MultipleRowsAffected(t *te
 	qe := NewQueryExecutor(mdb)
 
 	err := qe.ExecuteQueryAffectingSingleRow(context.TODO(), mqb)
-	assert.True(errors.IsErrorWithCode(err, errors.ErrSqlQueryDidNotAffectSingleRow))
+	assert.True(errors.IsErrorWithCode(err, errors.ErrSqlQueryAffectedMultipleRows))
 }
 
 type mockQueryBuilder struct {

--- a/pkg/db/query_executor_test.go
+++ b/pkg/db/query_executor_test.go
@@ -259,6 +259,23 @@ func TestQueryExecutor_ExecuteQueryAffectingSingleRow_ExecuteError(t *testing.T)
 	assert.Equal(errDefault, err)
 }
 
+func TestQueryExecutor_ExecuteQueryAffectingSingleRow_NoRowsAffected(t *testing.T) {
+	assert := assert.New(t)
+
+	mqb := mockQueryBuilder{}
+	mr := &mockResult{
+		affectedRows: 0,
+	}
+	mdb := &mockDb{
+		result: mr,
+	}
+
+	qe := NewQueryExecutor(mdb)
+
+	err := qe.ExecuteQueryAffectingSingleRow(context.TODO(), mqb)
+	assert.True(errors.IsErrorWithCode(err, errors.ErrSqlQueryDidNotAffectSingleRow))
+}
+
 func TestQueryExecutor_ExecuteQueryAffectingSingleRow_MultipleRowsAffected(t *testing.T) {
 	assert := assert.New(t)
 

--- a/pkg/db/result.go
+++ b/pkg/db/result.go
@@ -1,8 +1,37 @@
 package db
 
-import "github.com/jackc/pgx"
+import (
+	"github.com/jackc/pgx"
+)
 
-type Result struct {
-	tag pgx.CommandTag
-	Err error
+type Result interface {
+	Err() error
+	AffectedRows() int
+}
+
+type resultImpl struct {
+	affectedRows int
+	err          error
+}
+
+func newResult(tag pgx.CommandTag, sqlErr error) Result {
+	r := resultImpl{
+		err: sqlErr,
+	}
+
+	var err error
+	r.affectedRows, err = extractAffectedRowsFromCommandTag(tag)
+	if err != nil && r.err == nil {
+		r.err = err
+	}
+
+	return &r
+}
+
+func (r *resultImpl) Err() error {
+	return r.err
+}
+
+func (r *resultImpl) AffectedRows() int {
+	return r.affectedRows
 }

--- a/pkg/db/result_test.go
+++ b/pkg/db/result_test.go
@@ -1,0 +1,40 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/KnoblauchPilze/go-game/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResult_New(t *testing.T) {
+	assert := assert.New(t)
+
+	out := newResult("insert 0 12", nil)
+	assert.Nil(out.Err())
+	assert.Equal(12, out.AffectedRows())
+}
+
+func TestResult_New_WithError(t *testing.T) {
+	assert := assert.New(t)
+
+	out := newResult("insert 0 12", errDefault)
+	assert.Equal(errDefault, out.Err())
+	assert.Equal(12, out.AffectedRows())
+}
+
+func TestResult_New_InvalidTagAndError(t *testing.T) {
+	assert := assert.New(t)
+
+	out := newResult("not-a-valid-tag", errDefault)
+	assert.Equal(errDefault, out.Err())
+	assert.Equal(0, out.AffectedRows())
+}
+
+func TestResult_New_InvalidTag(t *testing.T) {
+	assert := assert.New(t)
+
+	out := newResult("not-a-valid-tag", nil)
+	assert.True(errors.IsErrorWithCode(out.Err(), errors.ErrInvalidSqlCommandTag))
+	assert.Equal(0, out.AffectedRows())
+}

--- a/pkg/db/result_test.go
+++ b/pkg/db/result_test.go
@@ -10,7 +10,7 @@ import (
 func TestResult_New(t *testing.T) {
 	assert := assert.New(t)
 
-	out := newResult("insert 0 12", nil)
+	out := newResult("INSERT 0 12", nil)
 	assert.Nil(out.Err())
 	assert.Equal(12, out.AffectedRows())
 }
@@ -18,7 +18,7 @@ func TestResult_New(t *testing.T) {
 func TestResult_New_WithError(t *testing.T) {
 	assert := assert.New(t)
 
-	out := newResult("insert 0 12", errDefault)
+	out := newResult("INSERT 0 12", errDefault)
 	assert.Equal(errDefault, out.Err())
 	assert.Equal(12, out.AffectedRows())
 }

--- a/pkg/errors/errors_table.go
+++ b/pkg/errors/errors_table.go
@@ -54,6 +54,7 @@ const (
 	ErrInvalidSqlQueryReceiverType
 	ErrNoRowsReturnedForSqlQuery
 	ErrSqlRowParsingFailed
+	ErrInvalidSqlCommandTag
 
 	ErrNotImplemented
 
@@ -111,6 +112,7 @@ var errorsCodeToMessage = map[ErrorCode]string{
 	ErrInvalidSqlQueryReceiverType: "invalid receiver of a sql query",
 	ErrNoRowsReturnedForSqlQuery:   "sql query returned no rows",
 	ErrSqlRowParsingFailed:         "parsing of sql row failed",
+	ErrInvalidSqlCommandTag:        "invalid sql command tag returned",
 
 	ErrNotImplemented: "not implemented",
 }

--- a/pkg/errors/errors_table.go
+++ b/pkg/errors/errors_table.go
@@ -55,6 +55,7 @@ const (
 	ErrNoRowsReturnedForSqlQuery
 	ErrSqlRowParsingFailed
 	ErrInvalidSqlCommandTag
+	ErrSqlQueryDidNotAffectSingleRow
 
 	ErrNotImplemented
 
@@ -104,15 +105,16 @@ var errorsCodeToMessage = map[ErrorCode]string{
 	ErrNoColumnInSqlInsertQuery:  "no column set for sql query",
 	ErrNoColumnInSqlUpdateQuery:  "no column set for sql query",
 
-	ErrDbCorruptedData:             "failed to interpret data from database",
-	ErrDbRequestCreationFailed:     "failed to create database request",
-	ErrDbRequestFailed:             "failed to query data from database",
-	ErrDbRequestTimeout:            "query to database timed out",
-	ErrMultiValuedDbElement:        "multiple values for expected unique database entry",
-	ErrInvalidSqlQueryReceiverType: "invalid receiver of a sql query",
-	ErrNoRowsReturnedForSqlQuery:   "sql query returned no rows",
-	ErrSqlRowParsingFailed:         "parsing of sql row failed",
-	ErrInvalidSqlCommandTag:        "invalid sql command tag returned",
+	ErrDbCorruptedData:               "failed to interpret data from database",
+	ErrDbRequestCreationFailed:       "failed to create database request",
+	ErrDbRequestFailed:               "sql query execution returned error",
+	ErrDbRequestTimeout:              "query to database timed out",
+	ErrMultiValuedDbElement:          "multiple values for expected unique database entry",
+	ErrInvalidSqlQueryReceiverType:   "invalid receiver of a sql query",
+	ErrNoRowsReturnedForSqlQuery:     "sql query returned no rows",
+	ErrSqlRowParsingFailed:           "parsing of sql row failed",
+	ErrInvalidSqlCommandTag:          "invalid sql command tag returned",
+	ErrSqlQueryDidNotAffectSingleRow: "sql query did not affect a single row",
 
 	ErrNotImplemented: "not implemented",
 }

--- a/pkg/errors/errors_table.go
+++ b/pkg/errors/errors_table.go
@@ -55,7 +55,9 @@ const (
 	ErrNoRowsReturnedForSqlQuery
 	ErrSqlRowParsingFailed
 	ErrInvalidSqlCommandTag
+	ErrUnknownSqlCommandTag
 	ErrSqlQueryDidNotAffectSingleRow
+	ErrSqlQueryAffectedMultipleRows
 
 	ErrNotImplemented
 
@@ -114,7 +116,9 @@ var errorsCodeToMessage = map[ErrorCode]string{
 	ErrNoRowsReturnedForSqlQuery:     "sql query returned no rows",
 	ErrSqlRowParsingFailed:           "parsing of sql row failed",
 	ErrInvalidSqlCommandTag:          "invalid sql command tag returned",
+	ErrUnknownSqlCommandTag:          "unknown sql command tag returned",
 	ErrSqlQueryDidNotAffectSingleRow: "sql query did not affect a single row",
+	ErrSqlQueryAffectedMultipleRows:  "sql query affected multiple rows",
 
 	ErrNotImplemented: "not implemented",
 }

--- a/pkg/users/db_repository.go
+++ b/pkg/users/db_repository.go
@@ -48,7 +48,7 @@ func (repo *userDbRepo) Create(ctx context.Context, user User) (uuid.UUID, error
 
 	qb.SetVerbose(true)
 
-	if err := repo.qe.RunQuery(ctx, qb); err != nil {
+	if err := repo.qe.ExecuteQuery(ctx, qb); err != nil {
 		return out, errors.WrapCode(err, errors.ErrUserCreationFailure)
 	}
 
@@ -103,7 +103,7 @@ func (repo *userDbRepo) Delete(ctx context.Context, id uuid.UUID) error {
 
 	qb.SetVerbose(true)
 
-	if err := repo.qe.RunQuery(ctx, qb); err != nil {
+	if err := repo.qe.ExecuteQuery(ctx, qb); err != nil {
 		return errors.WrapCode(err, errors.ErrUserDeletionFailure)
 	}
 

--- a/pkg/users/db_repository.go
+++ b/pkg/users/db_repository.go
@@ -48,7 +48,7 @@ func (repo *userDbRepo) Create(ctx context.Context, user User) (uuid.UUID, error
 
 	qb.SetVerbose(true)
 
-	if err := repo.qe.ExecuteQuery(ctx, qb); err != nil {
+	if err := repo.qe.ExecuteQueryAffectingSingleRow(ctx, qb); err != nil {
 		return out, errors.WrapCode(err, errors.ErrUserCreationFailure)
 	}
 
@@ -103,7 +103,7 @@ func (repo *userDbRepo) Delete(ctx context.Context, id uuid.UUID) error {
 
 	qb.SetVerbose(true)
 
-	if err := repo.qe.ExecuteQuery(ctx, qb); err != nil {
+	if err := repo.qe.ExecuteQueryAffectingSingleRow(ctx, qb); err != nil {
 		return errors.WrapCode(err, errors.ErrUserDeletionFailure)
 	}
 

--- a/pkg/users/db_repository_test.go
+++ b/pkg/users/db_repository_test.go
@@ -229,6 +229,9 @@ type mockQueryExecutor struct {
 	runQueryAndScanAllResultsCalled int
 	runQueryAndScanAllResultsErr    error
 
+	executeQueryCalled int
+	executeQueryErr    error
+
 	result  int
 	scanner *mockScannable
 
@@ -266,6 +269,13 @@ func (m *mockQueryExecutor) RunQueryAndScanAllResults(ctx context.Context, qb db
 	}
 
 	return m.runQueryAndScanAllResultsErr
+}
+
+func (m *mockQueryExecutor) ExecuteQuery(ctx context.Context, qb db.QueryBuilder) error {
+	m.executeQueryCalled++
+	m.queries = append(m.queries, qb)
+
+	return m.executeQueryErr
 }
 
 type mockFilterBuilder struct {

--- a/pkg/users/db_repository_test.go
+++ b/pkg/users/db_repository_test.go
@@ -220,9 +220,6 @@ func resetQueryBuilderFuncs() {
 }
 
 type mockQueryExecutor struct {
-	runQueryCalled int
-	runQueryErr    error
-
 	runQueryAndScanSingleResultCalled int
 	runQueryAndScanSingleResultErr    error
 
@@ -236,13 +233,6 @@ type mockQueryExecutor struct {
 	scanner *mockScannable
 
 	queries []db.QueryBuilder
-}
-
-func (m *mockQueryExecutor) RunQuery(ctx context.Context, qb db.QueryBuilder) error {
-	m.runQueryCalled++
-	m.queries = append(m.queries, qb)
-
-	return m.runQueryErr
 }
 
 func (m *mockQueryExecutor) RunQueryAndScanSingleResult(ctx context.Context, qb db.QueryBuilder, parser db.RowParser) error {
@@ -271,7 +261,7 @@ func (m *mockQueryExecutor) RunQueryAndScanAllResults(ctx context.Context, qb db
 	return m.runQueryAndScanAllResultsErr
 }
 
-func (m *mockQueryExecutor) ExecuteQuery(ctx context.Context, qb db.QueryBuilder) error {
+func (m *mockQueryExecutor) ExecuteQueryAffectingSingleRow(ctx context.Context, qb db.QueryBuilder) error {
 	m.executeQueryCalled++
 	m.queries = append(m.queries, qb)
 

--- a/pkg/users/db_repository_test.go
+++ b/pkg/users/db_repository_test.go
@@ -50,7 +50,7 @@ func TestDbRepository_CreateUser_QueryExecutorError(t *testing.T) {
 	assert := assert.New(t)
 
 	mqe := &mockQueryExecutor{
-		runQueryErr: errDefault,
+		executeQueryErr: errDefault,
 	}
 	repo := NewDbRepository(mqe)
 
@@ -69,7 +69,7 @@ func TestDbRepository_CreateUser(t *testing.T) {
 	out, err := repo.Create(context.TODO(), defaultTestUser)
 	assert.Nil(err)
 	assert.Equal(defaultTestUser.Id, out)
-	assert.Equal(1, mqe.runQueryCalled)
+	assert.Equal(1, mqe.executeQueryCalled)
 	assert.Equal(1, len(mqe.queries))
 
 	q, err := mqe.queries[0].Build()
@@ -132,7 +132,7 @@ func TestDbRepository_Delete_QueryExecutorError(t *testing.T) {
 	assert := assert.New(t)
 
 	mqe := &mockQueryExecutor{
-		runQueryErr: errDefault,
+		executeQueryErr: errDefault,
 	}
 	repo := NewDbRepository(mqe)
 
@@ -168,7 +168,7 @@ func TestDbRepository_Delete(t *testing.T) {
 
 	err := repo.Delete(context.TODO(), defaultTestUser.Id)
 	assert.Nil(err)
-	assert.Equal(1, mqe.runQueryCalled)
+	assert.Equal(1, mqe.executeQueryCalled)
 	assert.Equal(1, len(mqe.queries))
 
 	q, err := mqe.queries[0].Build()


### PR DESCRIPTION
### Work

We noticed that whenever creating a new user with the same email/id, the server return value was as if the operation succeeded when it didn't.
This is because we were using the `Query` method and not the `Execute`. We changed that, and also provided some verification about what happened (controlled of inserted/deleted rows).